### PR TITLE
homeworks/homework22:

### DIFF
--- a/homework22/pom.xml
+++ b/homework22/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ru.innopolis</groupId>
+    <artifactId>homework22</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.2</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.kafka</groupId>
+            <artifactId>reactor-kafka</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/homework22/src/main/java/ru/innopolis/App.java
+++ b/homework22/src/main/java/ru/innopolis/App.java
@@ -1,0 +1,14 @@
+package ru.innopolis;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+
+@SpringBootApplication
+public class App {
+
+    public static void main(String[] args) {
+        SpringApplication.run(App.class, args);
+    }
+
+}

--- a/homework22/src/main/java/ru/innopolis/config/KafkaConfig.java
+++ b/homework22/src/main/java/ru/innopolis/config/KafkaConfig.java
@@ -1,0 +1,56 @@
+package ru.innopolis.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.reactive.ReactiveKafkaConsumerTemplate;
+import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.sender.SenderOptions;
+import ru.innopolis.dto.KafkaMessage;
+
+import java.util.List;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConfig {
+
+    private final ObjectMapper mapper;
+    private final KafkaProperties kafkaProperties;
+
+
+    @Bean
+    public ReceiverOptions<String, KafkaMessage> receiverOptions() {
+        return ReceiverOptions.<String, KafkaMessage>create(kafkaProperties.buildConsumerProperties(null))
+                .subscription(List.of("topic"))
+                .withKeyDeserializer(new StringDeserializer())
+                .withValueDeserializer(new JsonDeserializer<>(KafkaMessage.class, mapper))
+                .consumerProperty(JsonDeserializer.TRUSTED_PACKAGES, "*");
+    }
+
+    @Bean
+    public ReactiveKafkaConsumerTemplate<String, KafkaMessage> reactiveKafkaConsumerTemplate() {
+        return new ReactiveKafkaConsumerTemplate<>(receiverOptions());
+    }
+
+    @Bean
+    public SenderOptions<String, KafkaMessage> senderOptions() {
+        return SenderOptions.<String, KafkaMessage>create(kafkaProperties.buildConsumerProperties(null))
+                .producerProperty(JsonSerializer.ADD_TYPE_INFO_HEADERS, false)
+                .withKeySerializer(new StringSerializer())
+                .withValueSerializer(new JsonSerializer<>(mapper));
+    }
+
+    @Bean
+    public ReactiveKafkaProducerTemplate<String, KafkaMessage> reactiveKafkaProducerTemplate() {
+        return new ReactiveKafkaProducerTemplate<>(senderOptions());
+    }
+
+}

--- a/homework22/src/main/java/ru/innopolis/dto/KafkaMessage.java
+++ b/homework22/src/main/java/ru/innopolis/dto/KafkaMessage.java
@@ -1,0 +1,20 @@
+package ru.innopolis.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class KafkaMessage {
+
+    private Long id;
+    private String message;
+    private LocalDateTime sendTime;
+
+}

--- a/homework22/src/main/java/ru/innopolis/functional/endpoint/KafkaHandler.java
+++ b/homework22/src/main/java/ru/innopolis/functional/endpoint/KafkaHandler.java
@@ -1,0 +1,31 @@
+package ru.innopolis.functional.endpoint;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+import ru.innopolis.kafka.KafkaProducer;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class KafkaHandler {
+
+    private final KafkaProducer kafkaProducer;
+
+    public Mono<ServerResponse> sendMessageToKafka(ServerRequest serverRequest) {
+
+        var count = Integer.valueOf(serverRequest
+                .queryParam("count")
+                .orElse("10"));
+
+        return kafkaProducer.sendMessage(count)
+                .then()
+                .flatMap(e -> ServerResponse.ok()
+                        .body(Mono.just("Отправлено сообщение"), String.class));
+    }
+
+}

--- a/homework22/src/main/java/ru/innopolis/functional/endpoint/KafkaRoute.java
+++ b/homework22/src/main/java/ru/innopolis/functional/endpoint/KafkaRoute.java
@@ -1,0 +1,31 @@
+package ru.innopolis.functional.endpoint;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class KafkaRoute {
+
+    private final KafkaHandler dataHandler;
+
+    @Bean
+    public RouterFunction<ServerResponse> kafkaEndpoint() {
+        return route()
+                .before(serverRequest -> {
+                    log.info("{} {}", serverRequest.method(), serverRequest.path());
+                    return serverRequest;
+                })
+                .POST("/kafka/send", dataHandler::sendMessageToKafka)
+                .build();
+    }
+
+}

--- a/homework22/src/main/java/ru/innopolis/kafka/KafkaConsumer.java
+++ b/homework22/src/main/java/ru/innopolis/kafka/KafkaConsumer.java
@@ -1,0 +1,20 @@
+package ru.innopolis.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.KafkaListener;
+import ru.innopolis.dto.KafkaMessage;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumer {
+
+    @KafkaListener(topics = "message", groupId = "group_id")
+    public void listen(KafkaMessage message) {
+        log.info("message: {}", message);
+    }
+
+}

--- a/homework22/src/main/java/ru/innopolis/kafka/KafkaProducer.java
+++ b/homework22/src/main/java/ru/innopolis/kafka/KafkaProducer.java
@@ -1,0 +1,44 @@
+package ru.innopolis.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import reactor.core.publisher.Flux;
+import reactor.kafka.sender.SenderResult;
+import ru.innopolis.dto.KafkaMessage;
+
+import java.time.LocalDateTime;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducer {
+
+    private final ReactiveKafkaProducerTemplate<String, KafkaMessage> reactiveKafkaProducerTemplate;
+
+    public Flux<SenderResult<Void>> sendMessage(Integer count) {
+        return Flux.range(0, count)
+                .map(i -> {
+                    String message = "Сообщение № " + i + " для кафки";
+                    var kafkaMessage = KafkaMessage.builder()
+                            .id(Long.valueOf(i))
+                            .message(message)
+                            .sendTime(LocalDateTime.now())
+                            .build();
+
+                    return MessageBuilder.withPayload(kafkaMessage)
+                            .setHeader(MessageHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                            .build();
+                })
+                .flatMap(kafkaMessage -> {
+                    log.info("Отправка сообщения в кафку: {}", kafkaMessage.getPayload().getId());
+                    return reactiveKafkaProducerTemplate.send("message", kafkaMessage);
+                });
+    }
+
+}

--- a/homework22/src/main/resources/application.yml
+++ b/homework22/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      group-id: my-group
+      properties:
+        reactiveAutoCommit: true
+        spring.json.trusted.packages: "*"
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
WebFlux. Создание сервиса, который отправляет в кафку сообщения и считывает их.

1. Кафка запущена в докер-контейнере с портом 9092.
2. Добавлен функциональный эндпоинт (/kafka/send) для отправки сообщений в кафку (KafkaHandler и KafkaRoute).
3. В кафку отправляются сообщение со следующими полями:
- id – идентификатор сообщения;
- message – текст сообщения;
- sendTime – дата и время отправки сообщения.
4. Добавлено логирование отправки сообщений в кафку.
5. Добавлен KafkaProducer для отправки сообщений и KafkaConsumer, для чтения сообщений.
6. сделаны скриншоты приложения.